### PR TITLE
V0.2.0

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 2,
-  "version": "0.1.0",
+  "version": "0.2.0",
   "name": "Dropbox Paper Indent Hide",
   "short_name": "Indent Hide",
   "description": "Hide content below specified indent in dropbox paper",

--- a/src/script.js
+++ b/src/script.js
@@ -1,17 +1,28 @@
+const SELECT_ID = 'indent-hide-select'
+
 const head = document.getElementsByTagName('head')[0]
-const backgroundColorStyle = document.createElement('style')
-backgroundColorStyle.innerText = `
+const baseStyle = document.createElement('style')
+baseStyle.innerText = `
   .listtype-task::after { background-color: red; }
   .listtype-taskdone::after { background-color: green; }
   .listtype-bullet::after { background-color: orange; }
   .listtype-indent::after { background-color: black; }
+
+  #${SELECT_ID} {
+    position:fixed;
+    bottom: 60px;
+    right: 20px;
+  }
+  #${SELECT_ID}:focus {
+    background-color: skyblue;
+  }
 `
 const style = document.createElement('style')
-head.append(backgroundColorStyle, style)
+head.append(baseStyle, style)
 
 const select = document.createElement('select')
-select.setAttribute('style', 'position: fixed; bottom: 60px; right: 20px;')
-select.innerHTML = '<option selected value="9"></option>' +
+select.setAttribute('id', SELECT_ID)
+select.innerHTML = '<option selected value="9">-</option>' +
   Array.from({length: 8}, (_, i) => (
     `<option value="${i + 1}">${i + 1}</option>`
   )).join('')
@@ -47,3 +58,9 @@ select.addEventListener('change', () => {
 
 const body = document.getElementsByTagName('body')[0]
 body.append(select)
+
+document.addEventListener('keypress', e => {
+  if (e.ctrlKey && e.shiftKey && e.key === 'I') {
+    select.focus()
+  }
+})

--- a/src/script.js
+++ b/src/script.js
@@ -1,15 +1,47 @@
 const head = document.getElementsByTagName('head')[0]
+const backgroundColorStyle = document.createElement('style')
+backgroundColorStyle.innerText = `
+  .listtype-task::after { background-color: red; }
+  .listtype-taskdone::after { background-color: green; }
+  .listtype-bullet::after { background-color: orange; }
+  .listtype-indent::after { background-color: black; }
+`
 const style = document.createElement('style')
-head.append(style)
+head.append(backgroundColorStyle, style)
 
 const select = document.createElement('select')
 select.setAttribute('style', 'position: fixed; bottom: 60px; right: 20px;')
 select.innerHTML = '<option selected value="9"></option>' +
-  Array.from({length: 8}, (_, i) => `<option value="${i + 1}">${i + 1}</option>`).join('')
+  Array.from({length: 8}, (_, i) => (
+    `<option value="${i + 1}">${i + 1}</option>`
+  )).join('')
 
 select.addEventListener('change', () => {
   const v = parseInt(select.value)
-  const css = Array.from({length: 9 - v}, (_, i) => `.listindent${i + v} {display: none;}`).join(' ')
+  const css = Array.from({length: 9 - v}, (_, i) => (`
+    .listindent${i + v} {
+      visibility: hidden;
+      height: 3px;
+      position: relative;
+    }
+    .listindent${i + v}::after {
+      content: "";
+      visibility: visible;
+      display: block;
+      height: 3px;
+      width: 1.5em;
+      position: absolute;
+      left: -1.5em;
+    }
+    .listindent${i + v} li {
+      display: none;
+    }
+    .line-list-type-bullet > .listindent${i + v},
+    .line-list-type-indent > .listindent${i + v} {
+      padding-top: 3px;
+      padding-bottom: 3px;
+    }
+  `)).join('')
   style.innerText = css
 })
 


### PR DESCRIPTION
- 要素を完全に隠すのではなく、ラインを表示するように
  - 赤: チェックのついてないタスク
  - 緑: チェックのついているタスク
  - 橙: ただのリスト
  - 黒: 普通の行
- "Ctrl-Shift-i"でセレクトタグにフォーカスが当たるように
- セレクトタグにフォーカスが当たっているときに色を変えるように